### PR TITLE
Fix: handling verify function edge case

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -85,13 +85,13 @@ function verifyWrapper(options, verify) {
     }
 
     var arity = verify.length;
-    if (arity == 6) {
+    if (arity === 6) {
       verify(req, accessToken, refreshToken, params, profile, verified);
     }
-    else if (arity == 5) {
+    else if (arity === 5 || arity === 0 /* if verify is created using rest parameters */) {
       verify(accessToken, refreshToken, params, profile, verified);
     }
-    else if (arity == 4) {
+    else if (arity === 4) {
       verify(accessToken, refreshToken, profile, verified);
     }
     else {


### PR DESCRIPTION
If the verify function is created using rest params, the length of that function (arity) will be 0, so we need to handle that case